### PR TITLE
Revert "allow handle_event to return {:ok, :idempotent} to make result more descriptive"

### DIFF
--- a/lib/spine/listener.ex
+++ b/lib/spine/listener.ex
@@ -62,10 +62,13 @@ defmodule Spine.Listener do
 
     case config.callback.handle_event(event, meta) do
       :ok ->
-        complete_event(event, cursor, config)
+        :telemetry.execute([:spine, :listener, :handle_event, :ok], %{count: 1}, %{
+          callback: config.callback,
+          event: event
+        })
 
-      {:ok, :idempotent} ->
-        complete_event(event, cursor, config)
+        config.spine.completed(config.channel, cursor)
+        cursor + 1
 
       other ->
         :telemetry.execute([:spine, :listener, :handle_event, :error], %{count: 1}, %{
@@ -76,15 +79,5 @@ defmodule Spine.Listener do
 
         cursor
     end
-  end
-
-  defp complete_event(event, cursor, config) do
-    :telemetry.execute([:spine, :listener, :handle_event, :ok], %{count: 1}, %{
-      callback: config.callback,
-      event: event
-    })
-
-    config.spine.completed(config.channel, cursor)
-    cursor + 1
   end
 end


### PR DESCRIPTION
Reverts ticketbuddy/spine#12

By allowing developers to return {:ok, :idempotent}, it allows them to by-pass necessary testing. e.g they test that `{:ok, :idempotent}` is returned, instead of checking the database wasn't affected, as these might not be the same thing.