### PR TITLE
mark cursor as completed if is above the expected cursor

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -2,6 +2,8 @@ import Mix.Config
 
 config :spine, ecto_repos: [Test.Support.Repo]
 
+config :logger, level: :warn
+
 config :spine, Test.Support.Repo,
   database: "spine",
   username: "postgres",

--- a/test/spine/bus/postgres_test.exs
+++ b/test/spine/bus/postgres_test.exs
@@ -38,18 +38,34 @@ defmodule Spine.BusDb.PostgresTest do
 
       assert :ok == PostgresTestDb.completed("channel-one", 0)
 
+      expected_next_cursor = 1
+
       assert %{
-               "channel-one" => 1
+               "channel-one" => expected_next_cursor
              } == PostgresTestDb.subscriptions()
     end
 
-    test "does not increment cursor when :completed message received for incorrect cursor" do
+    test "does increment if completed cursor is greater than current cursor" do
       PostgresTestDb.subscribe("channel-one")
 
-      assert :ok == PostgresTestDb.completed("channel-one", 2)
+      assert :ok == PostgresTestDb.completed("channel-one", 5)
+
+      expected_next_cursor = 6
 
       assert %{
-               "channel-one" => 1
+               "channel-one" => expected_next_cursor
+             } == PostgresTestDb.subscriptions()
+    end
+
+    test "does not increment cursor when :completed message received for a previous cursor" do
+      PostgresTestDb.subscribe("channel-one")
+
+      assert :ok == PostgresTestDb.completed("channel-one", -1)
+
+      expected_next_cursor = 1
+
+      assert %{
+               "channel-one" => expected_next_cursor
              } == PostgresTestDb.subscriptions()
     end
   end


### PR DESCRIPTION
It's not up to the subscriber that keeps the event count of each subscriber to keep the order. The order and completion of events should be ensured by the way events are read from the event store. 

The prevents a race condition putting the subscriber count permanently out-of-order, as it expects an exact number.

This is also, potentially another symptom of postgres not being able to count without skipping numbers.