### PR TITLE
must specify channels for strong consistency

### DIFF
--- a/lib/spine.ex
+++ b/lib/spine.ex
@@ -75,9 +75,9 @@ defmodule Spine do
         Spine.Aggregate.build_state(aggregate_id, events, handler)
       end
 
-      def wait_for_consistency(event_number, timeout \\ @default_consistency_timeout) do
+      def wait_for_consistency(channels, event_number, timeout \\ @default_consistency_timeout) do
         do_handle_consistency_guarantee(event_number,
-          consistency: :strong,
+          strong_consistency: channels,
           consistency_timeout: timeout
         )
       end
@@ -96,14 +96,14 @@ defmodule Spine do
       end
 
       defp do_handle_consistency_guarantee(event_number, opts) do
-        case Keyword.get(opts, :consistency, :eventual) do
-          :eventual ->
+        case Keyword.get(opts, :strong_consistency, []) do
+          [] ->
             :ok
 
-          :strong ->
+          channels ->
             timeout = Keyword.get(opts, :consistency_timeout, @default_consistency_timeout)
 
-            Spine.Consistency.wait_for_event(event_number, timeout)
+            Spine.Consistency.wait_for_event(channels, event_number, timeout)
         end
       end
     end

--- a/test/spine/consistency_test.exs
+++ b/test/spine/consistency_test.exs
@@ -59,13 +59,17 @@ defmodule Spine.ConsistencyTest do
 
       initial_subscriptions = %{
         "one" => 200,
-        "two" => 199
+        "two" => 199,
+        "three" => 150
       }
 
       strongly_consistent_subscriptions = %{
         "one" => 200,
-        "two" => 200
+        "two" => 200,
+        "three" => 150
       }
+
+      strongly_consistent_channels = ["one", "two"]
 
       BusDbMock
       |> expect(:subscriptions, fn ->
@@ -88,7 +92,8 @@ defmodule Spine.ConsistencyTest do
         send(test_pid, {:listener_progress_update, strongly_consistent_subscriptions})
       end)
 
-      assert {:timeout, event_number} == Spine.Consistency.wait_for_event(event_number, 600)
+      assert {:timeout, event_number} ==
+               Spine.Consistency.wait_for_event(strongly_consistent_channels, event_number, 600)
     end
 
     test "when subscriptions are strongly consistent", %{config: config} do
@@ -96,13 +101,17 @@ defmodule Spine.ConsistencyTest do
 
       initial_subscriptions = %{
         "one" => 199,
-        "two" => 200
+        "two" => 200,
+        "three" => 150
       }
 
       strongly_consistent_subscriptions = %{
         "one" => 200,
-        "two" => 200
+        "two" => 200,
+        "three" => 150
       }
+
+      strongly_consistent_channels = ["one", "two"]
 
       BusDbMock
       |> expect(:subscriptions, fn ->
@@ -125,7 +134,8 @@ defmodule Spine.ConsistencyTest do
         send(test_pid, {:listener_progress_update, strongly_consistent_subscriptions})
       end)
 
-      assert :ok == Spine.Consistency.wait_for_event(event_number, 600)
+      assert :ok ==
+               Spine.Consistency.wait_for_event(strongly_consistent_channels, event_number, 600)
     end
   end
 end

--- a/test/support/helper.ex
+++ b/test/support/helper.ex
@@ -5,6 +5,8 @@ defmodule Test.Support.Helper do
         unquote(repos)
         |> List.wrap()
         |> Enum.each(fn repo ->
+          start_supervised!(repo)
+
           :ok = Ecto.Adapters.SQL.Sandbox.checkout(repo)
 
           unless tags[:async] do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -4,8 +4,3 @@ Mox.defmock(ListenerCallbackMock, for: Spine.Listener.Callback)
 Mox.defmock(ListenerNotifierMock, for: Spine.Listener.Notifier)
 
 ExUnit.start()
-
-alias Test.Support.Repo
-
-{:ok, _} = Ecto.Adapters.Postgres.ensure_all_started(Repo, :temporary)
-{:ok, _pid} = Repo.start_link()


### PR DESCRIPTION
this:
- makes strong consistency more efficient as it ensures only the required parts of the system are strongly consistent
- makes it less error-prone to breaking when channels are decommissioned, because `Spine.subscriptions/0` returns all channels, active and in-active. Therefore, it might be waiting for strong consistency for a channel that is turned off.




**NOTE**
this introduces an intermittent postgrex error during the tests

```
15:50:50.728 [error] Postgrex.Protocol (#PID<0.294.0>) disconnected: ** (DBConnection.ConnectionError) owner #PID<0.434.0> exited

```

Started after adding the listener for the integration tests