### PR TITLE
listener to check for events on init. Improves resiliency for crashes and after deployments

### DIFF
--- a/lib/spine.ex
+++ b/lib/spine.ex
@@ -23,15 +23,16 @@ defmodule Spine do
       @type handler :: Atom.t()
       @type next_event_opts :: Keyword.t()
       @type opts :: [] | [idempotent_key: String.t()]
+      @type variant :: String.t()
 
       @callback commit(events, cursor) :: :ok
       @callback all_events() :: List.t()
       @callback aggregate_events(aggregate_id) :: List.t()
       @callback event(event_number) :: any()
-      @callback subscribe(channel, starting_event_number) :: :ok
+      @callback subscribe(channel, variant, starting_event_number) :: :ok
       @callback subscriptions() :: map()
-      @callback cursor(channel) :: non_neg_integer()
-      @callback completed(channel, cursor) :: :ok
+      @callback cursor(channel, variant) :: non_neg_integer()
+      @callback completed(channel, variant, cursor) :: :ok
       @callback handle(wish) :: :ok | any()
       @callback handle(wish, opts) :: :ok | any()
       @callback read(aggregate_id, handler) :: any()
@@ -42,10 +43,10 @@ defmodule Spine do
       defdelegate aggregate_events(aggregate_id), to: @event_store
       defdelegate event(event_number), to: @event_store
       defdelegate next_event(event_number, next_event_opts), to: @event_store
-      defdelegate subscribe(channel, starting_event_number), to: @bus
+      defdelegate subscribe(channel, variant, starting_event_number), to: @bus
       defdelegate subscriptions(), to: @bus
-      defdelegate cursor(channel), to: @bus
-      defdelegate completed(channel, cursor), to: @bus
+      defdelegate cursor(channel, variant), to: @bus
+      defdelegate completed(channel, variant, cursor), to: @bus
       defdelegate event_completed_notifier(), to: @bus
 
       def handle(wish, opts \\ []) do

--- a/lib/spine.ex
+++ b/lib/spine.ex
@@ -37,6 +37,7 @@ defmodule Spine do
       @callback handle(wish, opts) :: :ok | any()
       @callback read(aggregate_id, handler) :: any()
       @callback event_completed_notifier() :: Module.t()
+      @callback all_variants((() -> List.t()), Spine.BusDb.all_variants_opts()) :: {:ok, :ok}
 
       defdelegate commit(events, cursor, opts), to: @event_store
       defdelegate all_events(), to: @event_store
@@ -48,6 +49,7 @@ defmodule Spine do
       defdelegate cursor(channel, variant), to: @bus
       defdelegate completed(channel, variant, cursor), to: @bus
       defdelegate event_completed_notifier(), to: @bus
+      defdelegate all_variants(callback, query_opts), to: @bus
 
       def handle(wish, opts \\ []) do
         handler = Spine.Wish.aggregate_handler(wish)

--- a/lib/spine/bus_db.ex
+++ b/lib/spine/bus_db.ex
@@ -1,11 +1,12 @@
 defmodule Spine.BusDb do
   @type cursor :: Integer.t()
   @type channel :: String.t()
+  @type variant :: String.t()
   @type starting_event_number :: Integer.t()
 
-  @callback subscribe(channel, starting_event_number) :: {:ok, cursor}
+  @callback subscribe(channel, variant, starting_event_number) :: {:ok, cursor}
   @callback subscriptions() :: %{channel => {pid, cursor}}
-  @callback cursor(channel) :: cursor
-  @callback completed(channel, cursor) :: :ok
+  @callback cursor(channel, variant) :: cursor
+  @callback completed(channel, variant, cursor) :: :ok
   @callback event_completed_notifier() :: Module.t()
 end

--- a/lib/spine/bus_db.ex
+++ b/lib/spine/bus_db.ex
@@ -3,10 +3,12 @@ defmodule Spine.BusDb do
   @type channel :: String.t()
   @type variant :: String.t()
   @type starting_event_number :: Integer.t()
+  @type all_variants_opts :: [channel: String.t()]
 
   @callback subscribe(channel, variant, starting_event_number) :: {:ok, cursor}
   @callback subscriptions() :: %{channel => {pid, cursor}}
   @callback cursor(channel, variant) :: cursor
   @callback completed(channel, variant, cursor) :: :ok
   @callback event_completed_notifier() :: Module.t()
+  @callback all_variants((() -> List.t()), all_variants_opts) :: {:ok, :ok}
 end

--- a/lib/spine/bus_db/postgres.ex
+++ b/lib/spine/bus_db/postgres.ex
@@ -32,10 +32,11 @@ defmodule Spine.BusDb.Postgres do
   end
 
   def subscriptions(repo) do
-    repo.all(Schema.Subscription)
-    |> Enum.reduce(%{}, fn subscription, acc ->
-      Map.put(acc, subscription.channel, subscription.cursor)
-    end)
+    import Ecto.Query, only: [from: 2]
+
+    from(s in Schema.Subscription, group_by: [:channel], select: {s.channel, max(s.cursor)})
+    |> repo.all()
+    |> Map.new()
   end
 
   def cursor(repo, channel) do

--- a/lib/spine/bus_db/postgres/migration/subscription.ex
+++ b/lib/spine/bus_db/postgres/migration/subscription.ex
@@ -10,4 +10,12 @@ defmodule Spine.BusDb.Postgres.Migration.Subscription do
       timestamps()
     end
   end
+
+  def create_variant_field do
+    alter table("spine_subscription") do
+      remove(:channel)
+      add(:variant, :string, primary_key: true)
+      add(:channel, :string, primary_key: true)
+    end
+  end
 end

--- a/lib/spine/bus_db/postgres/schema/subscription.ex
+++ b/lib/spine/bus_db/postgres/schema/subscription.ex
@@ -5,6 +5,7 @@ defmodule Spine.BusDb.Postgres.Schema.Subscription do
 
   schema "spine_subscription" do
     field(:channel, :string, primary_key: true)
+    field(:variant, :string, primary_key: true)
     field(:starting_event_number, :integer)
     field(:cursor, :integer)
 
@@ -15,8 +16,8 @@ defmodule Spine.BusDb.Postgres.Schema.Subscription do
     import Ecto.Changeset
 
     %__MODULE__{}
-    |> cast(params, [:channel, :starting_event_number, :cursor, :channel])
-    |> validate_required([:channel, :starting_event_number, :cursor, :channel])
+    |> cast(params, [:channel, :variant, :starting_event_number, :cursor, :channel])
+    |> validate_required([:channel, :variant, :starting_event_number, :cursor, :channel])
     |> unique_constraint(:channel, name: :spine_subscription_pkey)
   end
 end

--- a/lib/spine/consistency.ex
+++ b/lib/spine/consistency.ex
@@ -2,9 +2,10 @@ defmodule Spine.Consistency do
   def wait_for_event(aggregate_id, notifier, [listener_callback], event_number, timeout) do
     notifier.subscribe()
 
-    channel = listener_callback.channel(aggregate_id)
+    channel = listener_callback.channel()
+    variant = listener_callback.variant(aggregate_id)
 
-    consistency_result = do_wait(channel, event_number, timeout)
+    consistency_result = do_wait(channel, variant, event_number, timeout)
 
     consistency_result
   end
@@ -13,9 +14,9 @@ defmodule Spine.Consistency do
     raise "Spine currently only supports strong consistency for one channel"
   end
 
-  defp do_wait(channel, event_number, timeout) do
+  defp do_wait(channel, variant, event_number, timeout) do
     receive do
-      {:listener_completed_event, ^channel, ^event_number} ->
+      {:listener_completed_event, ^channel, ^variant, ^event_number} ->
         :ok
     after
       timeout -> {:timeout, event_number}

--- a/lib/spine/event_store.ex
+++ b/lib/spine/event_store.ex
@@ -6,7 +6,7 @@ defmodule Spine.EventStore do
   @type cursor :: {aggregate_id, key}
   @type event_number :: Integer.t()
   @type opts :: [idempotent_key: String.t()] | []
-  @type channel_type :: :single | :by_aggregate
+  @type channel_type :: :single | :by_variant
 
   @callback commit(events, cursor, opts) :: {:ok, event_number} | {:ok, :idempotent} | :error
   @callback all_events() :: events

--- a/lib/spine/event_store/postgres.ex
+++ b/lib/spine/event_store/postgres.ex
@@ -112,7 +112,7 @@ defmodule Spine.EventStore.Postgres do
     end
   end
 
-  defp mutate_query_for_channel_type(query, by_aggregate: aggregate_id) do
+  defp mutate_query_for_channel_type(query, by_variant: aggregate_id) do
     require Ecto.Query
 
     Ecto.Query.where(query, [e], e.aggregate_id == ^aggregate_id)

--- a/lib/spine/listener.ex
+++ b/lib/spine/listener.ex
@@ -29,7 +29,7 @@ defmodule Spine.Listener do
     config = Map.put_new(config, :starting_event_number, @default_starting_number)
     init_state = config
 
-    GenServer.start_link(__MODULE__, init_state, name: {:global, config.callback.root_channel()})
+    GenServer.start_link(__MODULE__, init_state, name: {:global, config.callback.channel()})
   end
 
   def handle_info(:subscribe_to_event_store, config) do
@@ -40,21 +40,20 @@ defmodule Spine.Listener do
 
   def handle_info({:process, aggregate_id}, config) do
     listener_options = %{
-      channel: config.callback.channel(aggregate_id),
-      aggregate_id: aggregate_id,
+      channel: config.callback.channel(),
+      variant: config.callback.variant(aggregate_id),
       starting_event_number: config.starting_event_number,
       spine: config.spine,
       callback: config.callback
     }
 
     listener_child_spec = %{
-      id: {Listener.Worker, listener_options.channel},
+      id: {Listener.Worker, listener_options.channel <> listener_options.variant},
       start: {Listener.Worker, :start_link, [listener_options]},
       restart: :temporary
     }
 
     {:ok, pid} = find_or_start_worker(config.listener_supervisor, listener_child_spec)
-
     send(pid, :process)
 
     {:noreply, config}

--- a/lib/spine/listener/callback.ex
+++ b/lib/spine/listener/callback.ex
@@ -4,8 +4,8 @@ defmodule Spine.Listener.Callback do
 
   @callback handle_event(any, meta) :: :ok | any
   @callback concurrency() :: :single | :by_aggregate
-  @callback channel(aggregate_id) :: String.t()
-  @callback root_channel() :: String.t()
+  @callback variant(aggregate_id) :: String.t()
+  @callback channel() :: String.t()
 
   defmacro __using__(opts) do
     quote do
@@ -16,12 +16,12 @@ defmodule Spine.Listener.Callback do
 
       def concurrency, do: @concurrency
 
-      def root_channel, do: @channel
+      def channel, do: @channel
 
-      def channel(aggregate_id) do
+      def variant(aggregate_id) do
         case concurrency() do
-          :single -> "#{root_channel()}-single"
-          :by_aggregate -> "#{root_channel()}-#{aggregate_id}"
+          :single -> "single"
+          :by_aggregate -> aggregate_id
         end
       end
     end

--- a/priv/repo/migrations/20210228114710_subscription_variant.exs
+++ b/priv/repo/migrations/20210228114710_subscription_variant.exs
@@ -1,0 +1,7 @@
+defmodule Test.Support.Repo.Migrations.SubscriptionVariant do
+  use Ecto.Migration
+
+  def change do
+    Spine.BusDb.Postgres.Migration.Subscription.create_variant_field()
+  end
+end

--- a/test/spine/event_store/postgres_test.exs
+++ b/test/spine/event_store/postgres_test.exs
@@ -133,7 +133,7 @@ defmodule Spine.EventStore.PostgresTest do
       assert nil == PostgresTestDb.event(-50)
     end
 
-    test "fetches next event for by_aggregate channel type" do
+    test "fetches next event for by_variant channel type" do
       # event_number = 1
       aggregate_1_id = "basic-aggregate"
       aggregate_2_id = "aggregate-for-channel"
@@ -144,13 +144,13 @@ defmodule Spine.EventStore.PostgresTest do
       {:ok, expected_next_event} =
         PostgresTestDb.commit(%TestApp.Incremented{count: 333}, {aggregate_2_id, 1}, [])
 
-      assert {:ok, _event, %{event_number: retrieved_event_id_by_aggregate}} =
-               PostgresTestDb.next_event(event_number, by_aggregate: aggregate_2_id)
+      assert {:ok, _event, %{event_number: retrieved_event_id_by_variant}} =
+               PostgresTestDb.next_event(event_number, by_variant: aggregate_2_id)
 
       assert {:ok, _event, %{event_number: retrieved_event_id}} =
                PostgresTestDb.next_event(event_number, [])
 
-      assert expected_next_event == retrieved_event_id_by_aggregate
+      assert expected_next_event == retrieved_event_id_by_variant
       assert expected_next_event != retrieved_event_id
     end
   end

--- a/test/spine/listener/notifier_test.exs
+++ b/test/spine/listener/notifier_test.exs
@@ -31,7 +31,7 @@ defmodule Spine.Listener.NotifierTest do
     )
 
     BusDbMock
-    |> expect(:subscribe, fn "#{@listener_channel}-single", 1 -> {:ok, 1} end)
+    |> expect(:subscribe, fn @listener_channel, "single", 1 -> {:ok, 1} end)
 
     config = %{
       callback: ListenerCallback,

--- a/test/spine/listener/notifier_test.exs
+++ b/test/spine/listener/notifier_test.exs
@@ -33,6 +33,11 @@ defmodule Spine.Listener.NotifierTest do
     BusDbMock
     |> expect(:subscribe, fn @listener_channel, "single", 1 -> {:ok, 1} end)
 
+    BusDbMock
+    |> expect(:all_variants, fn _callback, channel: "notifier-test-channel" ->
+      {:ok, :ok}
+    end)
+
     config = %{
       callback: ListenerCallback,
       spine: MyApp,

--- a/test/spine/listener/worker_test.exs
+++ b/test/spine/listener/worker_test.exs
@@ -19,7 +19,7 @@ defmodule Spine.Listener.Worker.WorkerTest do
       spine: nil,
       notifier: nil,
       starting_event_number: 2,
-      aggregate_id: "aggregate-one"
+      variant: "aggregate-one"
     }
 
     assert {:ok, pid} = Spine.Listener.Worker.start_link(config)
@@ -30,7 +30,7 @@ defmodule Spine.Listener.Worker.WorkerTest do
     start_listening_from_event = 3
 
     BusDbMock
-    |> expect(:subscribe, fn "my-other-channel", start_listening_from_event ->
+    |> expect(:subscribe, fn "my-other-channel", "aggregate-one", start_listening_from_event ->
       {:ok, start_listening_from_event}
     end)
 
@@ -40,7 +40,7 @@ defmodule Spine.Listener.Worker.WorkerTest do
       spine: MyApp,
       notifier: ListenerNotifierMock,
       starting_event_number: start_listening_from_event,
-      aggregate_id: "aggregate-one"
+      variant: "aggregate-one"
     }
 
     assert {:ok, pid} = Spine.Listener.Worker.start_link(config)
@@ -53,7 +53,7 @@ defmodule Spine.Listener.Worker.WorkerTest do
               spine: MyApp,
               notifier: ListenerNotifierMock,
               starting_event_number: start_listening_from_event,
-              aggregate_id: "aggregate-one"
+              variant: "aggregate-one"
             }} == :sys.get_state(pid)
   end
 
@@ -78,7 +78,7 @@ defmodule Spine.Listener.Worker.WorkerTest do
     start_listening_from_event = 5
 
     BusDbMock
-    |> expect(:subscribe, fn "my-channel", ^start_listening_from_event ->
+    |> expect(:subscribe, fn "my-channel", "single", ^start_listening_from_event ->
       {:ok, start_listening_from_event}
     end)
 
@@ -86,7 +86,8 @@ defmodule Spine.Listener.Worker.WorkerTest do
       channel: "my-channel",
       spine: MyApp,
       notifier: ListenerNotifierMock,
-      starting_event_number: start_listening_from_event
+      starting_event_number: start_listening_from_event,
+      variant: "single"
     }
 
     existing_state = {start_listening_from_event, config}
@@ -105,7 +106,8 @@ defmodule Spine.Listener.Worker.WorkerTest do
       config = %{
         channel: "my-channel",
         spine: MyApp,
-        callback: ListenerCallbackMock
+        callback: ListenerCallbackMock,
+        variant: "single"
       }
 
       existing_state = {7, config}
@@ -134,14 +136,15 @@ defmodule Spine.Listener.Worker.WorkerTest do
       end)
 
       BusDbMock
-      |> expect(:completed, fn "my-channel", 9 ->
+      |> expect(:completed, fn "my-channel", "single", 9 ->
         :ok
       end)
 
       config = %{
         channel: "my-channel",
         spine: MyApp,
-        callback: ListenerCallbackMock
+        callback: ListenerCallbackMock,
+        variant: "single"
       }
 
       existing_state = {7, config}
@@ -171,7 +174,8 @@ defmodule Spine.Listener.Worker.WorkerTest do
       config = %{
         channel: "my-channel",
         spine: MyApp,
-        callback: ListenerCallbackMock
+        callback: ListenerCallbackMock,
+        variant: "single"
       }
 
       existing_state = {7, config}

--- a/test/spine/listener/worker_test.exs
+++ b/test/spine/listener/worker_test.exs
@@ -97,7 +97,7 @@ defmodule Spine.Listener.Worker.WorkerTest do
   end
 
   describe "handle_info/1 :process message" do
-    test "when the event does not exist, do not send :process message" do
+    test "stops worker when the event does not exist, and does not send :process message" do
       EventStoreMock
       |> expect(:next_event, fn 7, [] ->
         {:ok, :no_next_event}
@@ -112,7 +112,7 @@ defmodule Spine.Listener.Worker.WorkerTest do
 
       existing_state = {7, config}
 
-      assert {:noreply, {7, config}} ==
+      assert {:stop, :normal, {7, config}} ==
                Spine.Listener.Worker.handle_info(:process, existing_state)
 
       refute_receive(:process)

--- a/test/spine/listener_test.exs
+++ b/test/spine/listener_test.exs
@@ -22,8 +22,12 @@ defmodule Spine.ListenerTest do
   end
 
   test "starts a listener", %{config: config} do
-    expect(ListenerCallbackMock, :channel, fn ->
+    expect(ListenerCallbackMock, :channel, 2, fn ->
       "channel-one"
+    end)
+
+    expect(BusDbMock, :all_variants, fn _callback, channel: "channel-one" ->
+      {:ok, :ok}
     end)
 
     expect(ListenerNotifierMock, :subscribe, fn ->
@@ -33,5 +37,37 @@ defmodule Spine.ListenerTest do
     assert {:ok, pid} = Spine.Listener.start_link(config)
     assert is_pid(pid)
     assert Map.put(config, :starting_event_number, 1) == :sys.get_state(pid)
+  end
+
+  test "on listener init, subscribes to notifier, and starts processing all aggregates", %{
+    config: config
+  } do
+    expect(ListenerNotifierMock, :subscribe, fn -> :ok end)
+
+    assert {:ok, config} == Spine.Listener.init(config)
+    assert_receive(:_process_all_aggregates)
+  end
+
+  test "receive :_process_all_aggregates, starts processing all aggregates", %{config: config} do
+    config = Map.put(config, :starting_event_number, 1)
+
+    expect(ListenerCallbackMock, :channel, 4, fn ->
+      "some-channel"
+    end)
+
+    expect(ListenerCallbackMock, :variant, 3, fn
+      aggregate_id -> aggregate_id
+    end)
+
+    expect(BusDbMock, :all_variants, fn callback, channel: "some-channel" ->
+      callback.(["aggregate-one", "aggregate-two", "aggregate-three"])
+
+      {:ok, :ok}
+    end)
+
+    assert {:noreply, config} == Spine.Listener.handle_info(:_process_all_aggregates, config)
+
+    assert %{active: 3, specs: 3, supervisors: 0, workers: 3} =
+             DynamicSupervisor.count_children(FakeListenerDynamicSupervisor)
   end
 end

--- a/test/spine/listener_test.exs
+++ b/test/spine/listener_test.exs
@@ -1,0 +1,37 @@
+defmodule Spine.ListenerTest do
+  use ExUnit.Case
+  use Test.Support.Mox
+
+  defmodule MyApp do
+    use Spine, event_store: EventStoreMock, bus: BusDbMock
+  end
+
+  setup do
+    start_supervised!(
+      {DynamicSupervisor, strategy: :one_for_one, name: FakeListenerDynamicSupervisor}
+    )
+
+    %{
+      config: %{
+        listener_supervisor: FakeListenerDynamicSupervisor,
+        notifier: ListenerNotifierMock,
+        spine: MyApp,
+        callback: ListenerCallbackMock
+      }
+    }
+  end
+
+  test "starts a listener", %{config: config} do
+    expect(ListenerCallbackMock, :channel, fn ->
+      "channel-one"
+    end)
+
+    expect(ListenerNotifierMock, :subscribe, fn ->
+      :ok
+    end)
+
+    assert {:ok, pid} = Spine.Listener.start_link(config)
+    assert is_pid(pid)
+    assert Map.put(config, :starting_event_number, 1) == :sys.get_state(pid)
+  end
+end


### PR DESCRIPTION
- controversially starts all listeners and varies on their aggregates upon start

maybe a follow up PR to make this more efficient!?