### PR TITLE
At least twice message delivery to listeners

### DIFF
--- a/lib/spine.ex
+++ b/lib/spine.ex
@@ -37,7 +37,6 @@ defmodule Spine do
       @callback handle(wish, opts) :: :ok | any()
       @callback read(aggregate_id, handler) :: any()
       @callback event_completed_notifier() :: Module.t()
-      @callback all_variants((() -> List.t()), Spine.BusDb.all_variants_opts()) :: {:ok, :ok}
 
       defdelegate commit(events, cursor, opts), to: @event_store
       defdelegate all_events(), to: @event_store
@@ -49,7 +48,6 @@ defmodule Spine do
       defdelegate cursor(channel, variant), to: @bus
       defdelegate completed(channel, variant, cursor), to: @bus
       defdelegate event_completed_notifier(), to: @bus
-      defdelegate all_variants(callback, query_opts), to: @bus
 
       def handle(wish, opts \\ []) do
         handler = Spine.Wish.aggregate_handler(wish)

--- a/lib/spine/bus_db.ex
+++ b/lib/spine/bus_db.ex
@@ -3,12 +3,10 @@ defmodule Spine.BusDb do
   @type channel :: String.t()
   @type variant :: String.t()
   @type starting_event_number :: Integer.t()
-  @type all_variants_opts :: [channel: String.t()]
 
   @callback subscribe(channel, variant, starting_event_number) :: {:ok, cursor}
   @callback subscriptions() :: %{channel => {pid, cursor}}
   @callback cursor(channel, variant) :: cursor
   @callback completed(channel, variant, cursor) :: :ok
   @callback event_completed_notifier() :: Module.t()
-  @callback all_variants((() -> List.t()), all_variants_opts) :: {:ok, :ok}
 end

--- a/lib/spine/bus_db/postgres.ex
+++ b/lib/spine/bus_db/postgres.ex
@@ -47,20 +47,6 @@ defmodule Spine.BusDb.Postgres do
     |> Map.new()
   end
 
-  def all_variants(repo, callback, channel: channel) do
-    repo.transaction(fn ->
-      from(s in Schema.Subscription,
-        order_by: s.updated_at,
-        where: s.channel == ^channel,
-        select: s.variant
-      )
-      |> repo.stream()
-      |> Stream.chunk_every(@chunk_variants)
-      |> Stream.each(callback)
-      |> Stream.run()
-    end)
-  end
-
   def cursor(repo, channel, variant) do
     repo.get_by!(Schema.Subscription, channel: channel, variant: variant)
     |> case do
@@ -119,10 +105,6 @@ defmodule Spine.BusDb.Postgres do
 
       def subscriptions do
         Postgres.subscriptions(@repo)
-      end
-
-      def all_variants(callback, query_opts) do
-        Postgres.all_variants(@repo, callback, query_opts)
       end
 
       def cursor(channel, variant) do

--- a/test/spine/bus/postgres_test.exs
+++ b/test/spine/bus/postgres_test.exs
@@ -52,51 +52,6 @@ defmodule Spine.BusDb.PostgresTest do
     end
   end
 
-  describe "all_variants/2" do
-    setup do
-      channel_one = "channel-one"
-      channel_two = "channel-two"
-
-      variant_one = "aggregate-one"
-      variant_two = "aggregate-two"
-      variant_three = "aggregate-three"
-      variant_four = "aggregate-four"
-
-      for channel <- [channel_one, channel_two] do
-        PostgresTestDb.subscribe(channel, variant_one, @start_listening_from)
-        PostgresTestDb.subscribe(channel, variant_two, @start_listening_from)
-        PostgresTestDb.subscribe(channel, variant_three, @start_listening_from)
-        PostgresTestDb.subscribe(channel, variant_four, @start_listening_from)
-      end
-
-      PostgresTestDb.completed(channel_one, variant_two, 4)
-      PostgresTestDb.completed(channel_one, variant_three, 7)
-      PostgresTestDb.completed(channel_one, variant_four, 2)
-
-      PostgresTestDb.completed(channel_two, variant_two, 4)
-      PostgresTestDb.completed(channel_two, variant_three, 2)
-      PostgresTestDb.completed(channel_two, variant_four, 13)
-
-      :ok
-    end
-
-    test "by channel" do
-      test_pid = self()
-
-      cb = fn batch ->
-        assert "aggregate-one" in batch
-        assert "aggregate-two" in batch
-        assert "aggregate-three" in batch
-        assert "aggregate-four" in batch
-
-        send(test_pid, :received_batch)
-      end
-
-      assert {:ok, :ok} == PostgresTestDb.all_variants(cb, channel: "channel-one")
-      assert_receive(:received_batch)
-    end
-  end
-
   test "get cursor for the channel" do
     channel = "channel-one"
     variant = "aggregate-one"

--- a/test/spine/listener/notifier_test.exs
+++ b/test/spine/listener/notifier_test.exs
@@ -33,11 +33,6 @@ defmodule Spine.Listener.NotifierTest do
     BusDbMock
     |> expect(:subscribe, fn @listener_channel, "single", 1 -> {:ok, 1} end)
 
-    BusDbMock
-    |> expect(:all_variants, fn _callback, channel: "notifier-test-channel" ->
-      {:ok, :ok}
-    end)
-
     config = %{
       callback: ListenerCallback,
       spine: MyApp,


### PR DESCRIPTION
Starts a "trailing" worker on listener startup, that will process **all** events using the `"single"` variant.

This ensures that events will be ran at least twice.

**Pros**
- Does not query all aggregates on listener init.

**Cons**
- All events are processed twice by listeners
- Repeated events might be from a long time ago. e.g some third parties offering idempotency only lasts 24 hours (e.g Stripe)
